### PR TITLE
WIP: set the ROOT prefix when building genfit.

### DIFF
--- a/var/spack/repos/builtin/packages/genfit/package.py
+++ b/var/spack/repos/builtin/packages/genfit/package.py
@@ -18,3 +18,11 @@ class Genfit(CMakePackage):
     version('master', branch='master')
 
     depends_on('root')
+
+
+    def cmake_args(self):
+        args = []
+        root_prefix = self.spec["root"].prefix
+        args.append('-DROOT_DIR=%s'%root_prefix)
+
+        return args


### PR DESCRIPTION
Try to force GenFit using the ROOT from spack. From https://github.com/key4hep/key4hep-spack/issues/157, it looks like the ROOT cling can't locate the header file. One possible problem would be that there are multiple ROOT versions installed, and the wrong ROOT is picked to build GenFit. 